### PR TITLE
Use machine type for include path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ def get_ext_modules():
                 'kent',
             ] + d.pop('libraries', []),
             library_dirs=[
-                op.join(thisdir, 'src/x86_64'),
+                op.join(thisdir, f'src/{os.uname().machine}'),
             ] + d.pop('library_dirs', []),
             include_dirs=[
                 numpy.get_include(),


### PR DESCRIPTION
Fixes https://github.com/nvictus/pybbi/issues/17

Kent tools output their library to `src/$(MACHTYPE)/libkent.a` but `setup.py` has the linker path hardcoded to `x86_64`. This leads to the python setup script not finding the library and failing. This PR uses an architecture-specific linker path in setup.py.