### PR TITLE
Do not use function pointers of unspecified arguments

### DIFF
--- a/include/bedTabix.h
+++ b/include/bedTabix.h
@@ -12,7 +12,7 @@ struct lineFile *lf;
 struct bedTabixFile *bedTabixFileMayOpen(char *fileOrUrl, char *chrom, int start, int end);
 /* Open a bed file that has been compressed and indexed by tabix */
 
-struct bed *bedTabixReadBeds(struct bedTabixFile *btf, char *chromName, int winStart, int winEnd, struct bed * (*loadBed)(), int minScore);
+struct bed *bedTabixReadBeds(struct bedTabixFile *btf, char *chromName, int winStart, int winEnd, struct bed * (*loadBed)(void *), int minScore);
 
 void bedTabixFileClose(struct bedTabixFile *btf);
 #endif //BEDTABIX_H

--- a/include/common.h
+++ b/include/common.h
@@ -423,7 +423,7 @@ void slSort(void *pList, CmpFunction *compare);
  * The arguments to the compare function in real, non-void, life
  * are pointers to pointers. */
 
-void slUniqify(void *pList, CmpFunction *compare, void (*free)());
+void slUniqify(void *pList, CmpFunction *compare, void (*free)(void *));
 /* Return sorted list with duplicates removed.
  * Compare should be same type of function as slSort's compare (taking
  * pointers to pointers to elements.  Free should take a simple
@@ -432,7 +432,7 @@ void slUniqify(void *pList, CmpFunction *compare, void (*free)());
 void slSortMerge(void *pA, void *b, CmpFunction *compare);
 // Merges and sorts a pair of singly linked lists using slSort.
 
-void slSortMergeUniq(void *pA, void *b, CmpFunction *compare, void (*free)());
+void slSortMergeUniq(void *pA, void *b, CmpFunction *compare, void (*free)(void *));
 // Merges and sorts a pair of singly linked lists leaving only unique
 // items via slUniqufy.  duplicate itens are defined by the compare routine
 // returning 0. If free is provided, items dropped from list can disposed of.

--- a/include/hash.h
+++ b/include/hash.h
@@ -250,7 +250,7 @@ void freeHashAndVals(struct hash **pHash);
 /* Free up hash table and all values associated with it.
  * (Just calls freeMem on each hel->val) */
 
-void hashFreeWithVals(struct hash **pHash, void (freeFunc)());
+void hashFreeWithVals(struct hash **pHash, void (freeFunc)(void **));
 /* Free up hash table and all values associated with it. freeFunc is a
  * function to free an entry, should take a pointer to a pointer to an
  * entry. */

--- a/src/common.c
+++ b/src/common.c
@@ -341,7 +341,7 @@ if (count > 1)
     }
 }
 
-void slUniqify(void *pList, int (*compare )(const void *elem1,  const void *elem2), void (*free)())
+void slUniqify(void *pList, int (*compare )(const void *elem1,  const void *elem2), void (*free)(void *))
 /* Return sorted list with duplicates removed.
  * Compare should be same type of function as slSort's compare (taking
  * pointers to pointers to elements.  Free should take a simple
@@ -371,7 +371,7 @@ slCat(*pList, b);
 slSort(pList,compare);
 }
 
-void slSortMergeUniq(void *pA, void *b, CmpFunction *compare, void (*free)())
+void slSortMergeUniq(void *pA, void *b, CmpFunction *compare, void (*free)(void *))
 // Merges and sorts a pair of singly linked lists leaving only unique
 // items via slUniqufy.  duplicate itens are defined by the compare routine
 // returning 0. If free is provided, items dropped from list can disposed of.

--- a/src/hash.c
+++ b/src/hash.c
@@ -638,7 +638,7 @@ if ((hash = *pHash) != NULL)
     }
 }
 
-void hashFreeWithVals(struct hash **pHash, void (freeFunc)())
+void hashFreeWithVals(struct hash **pHash, void (freeFunc)(void **))
 /* Free up hash table and all values associated with it. freeFunc is a
  * function to free an entry, should take a pointer to a pointer to an
  * entry. */


### PR DESCRIPTION
This is necessary in order to build with C23, which is the default standard in GCC 15.

In C23, `int foo()` is no longer a function taking unspecified arguments, but a function taking no arguments, like `int foo(void)`.

Furthermore, treating a pointer to a function of unspecified arguments as compatible with a pointer to a function with declared arguments was probably always dubious, although it worked in practice.